### PR TITLE
#169851150 Get a specific red-flag/intervention

### DIFF
--- a/server/api/v1/controllers/redFlagController.js
+++ b/server/api/v1/controllers/redFlagController.js
@@ -3,8 +3,7 @@ import responseMsg from '../heplpers/responseMsg'
 import fs from 'fs'
 import findById from "../heplpers/findById";
 import redFlags from '../models/red-flag'
-
-
+import checkInt from '../heplpers/checkInt'
 
 
 export default class RedFlagController {
@@ -68,4 +67,21 @@ export default class RedFlagController {
            }]
        })
    }
+/**
+* @description This helps the authorized User to fetch a specific red-flag/intervention
+* @param  {object} req - The request object
+* @param  {object} res - The response object
+*/
+static async getOne(req, res) {
+    const { red_flag_id } = req.params
+    if (!checkInt(red_flag_id)) {
+        responseMsg.errorMsg(res, 403, 'red-flag-id must be an integer and less than 8 in length')
+    }
+    let item = findById(redFlags, red_flag_id)
+    if (!item) throw responseMsg.errorMsg(res, 404, 'red-flag-id not found')
+    res.status(200).json({
+        status: 200,
+        data: item
+    })
+}
 }

--- a/server/api/v1/routes/redFlag-Intervention.js
+++ b/server/api/v1/routes/redFlag-Intervention.js
@@ -10,5 +10,6 @@ const router = express.Router();
 router.post("/", authanticationJWT,createRedFlagValidator,redFlagController.create)
 router.patch("/:red_flag_id/location", authanticationJWT, locationRedFlagValidator, redFlagController.updateLocation)
 router.patch("/:red_flag_id/comment", authanticationJWT, commentRedFlagValidator, redFlagController.updateComment)
+router.get("/:red_flag_id", authanticationJWT,  redFlagController.getOne)
 
 export default router;

--- a/server/test/v1/specific.test.js
+++ b/server/test/v1/specific.test.js
@@ -1,0 +1,26 @@
+import chai from 'chai'
+import chaiHttp from 'chai-http'
+import supertest from 'supertest'
+
+chai.use(chaiHttp);
+chai.should();
+chai.expect();
+
+
+describe('Fetch red-flag/intervention', () => {
+    describe('Get specific red-flag/intervention', () => {
+        it('User should receive a successful get red-flag/intervention message', (done) => {
+            supertest('http://localhost:8080/api/v1')
+                .get('/red-flags/1')
+                .set('Accept', 'application/json')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCRVYS9hRnJOeFdnb3hoN29sRUYxNXh1SGZ2NS96czBQcWdxWTVFWnhZcEs3MmJOeDBWUFRNQyIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzQxNzg4NjJ9.35BfeXMkhkFWvh6CbQiTMxyUBl5O9V8-zIqrC_ewivU')
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
+   
+})


### PR DESCRIPTION
### What does this Pr do ?
Fetch a specific red-flag record
### Description of the task to be completed ?
- Users should be able to view a specific red-flag/intervention only if it exists in memory
- Users can only fetch the articles by their `id`s
- To view an red-flag/intervention Users should send the `id` of the red-flag/intervention in the url it self.
- To make sure the right people consumes this API, who ever is hitting this endpoint should only use his/her  JWT token that  they received when they created credentials to this API or Sign in to it sent in headers.
- Users should receive a message specifying that they successfully fetched with the article and its description or an error with description if it didn't.
- add testing

have the following endpoint work 
- GET /api/v1/red-flags/`:red-flag-id`

### How should this be manually tested?
after cloning this repository, od into it and RUN `npm i` after `npm start`
- Using postman test the endpoint above

Set key: Content-type value: application/json
make sure you have a JWT token in the headers with key:token value: JWT token generated while signing up or signing in
### Any background context you want to provide?
N/A
### What are the relevant pivot tracker stories ?
#169851150
https://www.pivotaltracker.com/story/show/169851150

#### screenshots if available?
![image](https://user-images.githubusercontent.com/37307172/69185655-d691ea00-0b1f-11ea-9655-8bd9a3e3a4ea.png)
