### PR TITLE
#169852247 Fetch all red-flags

### DIFF
--- a/server/api/v1/controllers/redFlagController.js
+++ b/server/api/v1/controllers/redFlagController.js
@@ -84,4 +84,15 @@ static async getOne(req, res) {
         data: item
     })
 }
+    /**
+    * @description This helps the authorized User to fetch all red-flag/intervention
+    * @param  {object} req - The request object
+    * @param  {object} res - The response object
+    */
+    static async getAll(req, res) {
+        res.status(200).json({
+            status: 200,
+            data: redFlags
+        })
+    }
 }

--- a/server/api/v1/routes/redFlag-Intervention.js
+++ b/server/api/v1/routes/redFlag-Intervention.js
@@ -11,5 +11,6 @@ router.post("/", authanticationJWT,createRedFlagValidator,redFlagController.crea
 router.patch("/:red_flag_id/location", authanticationJWT, locationRedFlagValidator, redFlagController.updateLocation)
 router.patch("/:red_flag_id/comment", authanticationJWT, commentRedFlagValidator, redFlagController.updateComment)
 router.get("/:red_flag_id", authanticationJWT,  redFlagController.getOne)
+router.get("/", authanticationJWT,  redFlagController.getAll)
 
 export default router;

--- a/server/test/v1/specific.test.js
+++ b/server/test/v1/specific.test.js
@@ -22,5 +22,19 @@ describe('Fetch red-flag/intervention', () => {
                 });
         });
     });
+    describe('Get all red-flag/intervention', () => {
+        it('User should receive a successful get red-flag/intervention message', (done) => {
+            supertest('http://localhost:8080/api/v1')
+                .get('/red-flags')
+                .set('Accept', 'application/json')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCRVYS9hRnJOeFdnb3hoN29sRUYxNXh1SGZ2NS96czBQcWdxWTVFWnhZcEs3MmJOeDBWUFRNQyIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzQxNzg4NjJ9.35BfeXMkhkFWvh6CbQiTMxyUBl5O9V8-zIqrC_ewivU')
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
    
 })


### PR DESCRIPTION
### What does this Pr do ?
User should be able to fetch all red-flag records
### Description of the task to be completed ?
- Users should only be able to view stored red-flags/interventions
- To make sure the right people consumes this API, who ever is hitting this endpoint should only use his/her  JWT token that  they received when they created credentials to this API or Sign in to it sent in headers.
- Employee should receive an message specifying that fetching all  red-flags/interventions was successfully and receive all  red-flags/interventions or an error with description if it didn't.
- add testing

have the following endpoint work 
- GET /api/v1/red-flags/`:red-flag-id`

### How should this be manually tested?
after cloning this repository, od into it and RUN `npm i` after `npm start`
- Using postman test the endpoint above

Set key: Content-type value: application/json
make sure you have a JWT token in the headers with key:token value: JWT token generated while signing up or signing in
### Any background context you want to provide?
N/A
### What are the relevant pivot tracker stories ?
#169852247
https://www.pivotaltracker.com/story/show/169852247

#### screenshots if available?
![image](https://user-images.githubusercontent.com/37307172/69187611-9f253c80-0b23-11ea-9ef7-b518f8a7ca87.png)
