### PR TITLE
#169853269 Delete a red-flag/intervention

### DIFF
--- a/server/api/v1/models/red-flag.js
+++ b/server/api/v1/models/red-flag.js
@@ -7,15 +7,8 @@ const redFlags = [{
     "comment": "this is the comment about the red-flag",
     "created_on": "2019-11-18T16:22:34.000Z",
     "status": "draft",
-    "images": [
-        "uploads\\images\\2019-11-18T16-22-34.251Z-7bBYA.png",
-        "uploads\\images\\2019-11-18T16-22-34.254Z-download (1).jpg",
-        "uploads\\images\\2019-11-18T16-22-34.254Z-koala_top-672x372.png"
-    ],
-    "videos": [
-        "uploads\\videos\\2019-11-18T16-22-34.259Z-small.mp4",
-        "uploads\\videos\\2019-11-18T16-22-34.261Z-TRA3106.mp4"
-    ]
+    "images": [],
+    "videos": []
 }]
 
 export default redFlags

--- a/server/api/v1/routes/redFlag-Intervention.js
+++ b/server/api/v1/routes/redFlag-Intervention.js
@@ -12,5 +12,6 @@ router.patch("/:red_flag_id/location", authanticationJWT, locationRedFlagValidat
 router.patch("/:red_flag_id/comment", authanticationJWT, commentRedFlagValidator, redFlagController.updateComment)
 router.get("/:red_flag_id", authanticationJWT,  redFlagController.getOne)
 router.get("/", authanticationJWT,  redFlagController.getAll)
+router.delete("/:red_flag_id", authanticationJWT,  redFlagController.delete)
 
 export default router;

--- a/server/test/v1/specific.test.js
+++ b/server/test/v1/specific.test.js
@@ -13,10 +13,24 @@ describe('Fetch red-flag/intervention', () => {
             supertest('http://localhost:8080/api/v1')
                 .get('/red-flags/1')
                 .set('Accept', 'application/json')
-                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCRVYS9hRnJOeFdnb3hoN29sRUYxNXh1SGZ2NS96czBQcWdxWTVFWnhZcEs3MmJOeDBWUFRNQyIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzQxNzg4NjJ9.35BfeXMkhkFWvh6CbQiTMxyUBl5O9V8-zIqrC_ewivU')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCRGaHNucDd3SWh4ZkZYeFAvVVRBY0ZPQ1gxdDVnUng2N1V5Lk8yTk1xZ2ticndTdjJoOWJpeSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzQyMDEyNDd9.MEDVcS6wTh45CTHmcR04sltn6GBrGhf9jAl8uYndTdM')
                 .expect('Content-Type', /json/)
                 .end((err, res) => {
                     res.should.have.status(200);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
+    describe('Get specific red-flag/intervention', () => {
+        it('User should receive an error get red-flag id format', (done) => {
+            supertest('http://localhost:8080/api/v1')
+                .get('/red-flags/g')
+                .set('Accept', 'application/json')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCRGaHNucDd3SWh4ZkZYeFAvVVRBY0ZPQ1gxdDVnUng2N1V5Lk8yTk1xZ2ticndTdjJoOWJpeSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzQyMDEyNDd9.MEDVcS6wTh45CTHmcR04sltn6GBrGhf9jAl8uYndTdM')
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(403);
                     res.should.be.a('object');
                     done();
                 });
@@ -27,7 +41,7 @@ describe('Fetch red-flag/intervention', () => {
             supertest('http://localhost:8080/api/v1')
                 .get('/red-flags')
                 .set('Accept', 'application/json')
-                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCRVYS9hRnJOeFdnb3hoN29sRUYxNXh1SGZ2NS96czBQcWdxWTVFWnhZcEs3MmJOeDBWUFRNQyIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzQxNzg4NjJ9.35BfeXMkhkFWvh6CbQiTMxyUBl5O9V8-zIqrC_ewivU')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCRGaHNucDd3SWh4ZkZYeFAvVVRBY0ZPQ1gxdDVnUng2N1V5Lk8yTk1xZ2ticndTdjJoOWJpeSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzQyMDEyNDd9.MEDVcS6wTh45CTHmcR04sltn6GBrGhf9jAl8uYndTdM')
                 .expect('Content-Type', /json/)
                 .end((err, res) => {
                     res.should.have.status(200);

--- a/server/test/v1/updateLocation.test.js
+++ b/server/test/v1/updateLocation.test.js
@@ -130,4 +130,20 @@ describe('Location', () => {
                 });
         });
     });
+    describe('Delete red-flag/intervention', () => {
+        describe('delete specific red-flag/intervention', () => {
+            it('User should receive a successful delete red-flag/intervention message', (done) => {
+                supertest('http://localhost:8080/api/v1')
+                    .delete('/red-flags/1')
+                    .set('Accept', 'application/json')
+                    .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCRGaHNucDd3SWh4ZkZYeFAvVVRBY0ZPQ1gxdDVnUng2N1V5Lk8yTk1xZ2ticndTdjJoOWJpeSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzQyMDEyNDd9.MEDVcS6wTh45CTHmcR04sltn6GBrGhf9jAl8uYndTdM')
+                    .expect('Content-Type', /json/)
+                    .end((err, res) => {
+                        res.should.have.status(200);
+                        res.should.be.a('object');
+                        done();
+                    });
+            });
+        });
+    })
 })


### PR DESCRIPTION
### What does this Pr do ?
Delete a specific red flag record
### Description of the task to be completed ?
- Users should be able to delete their own red-flags/interventions if they exists.
- To delete their red-flags/interventions Users should send the `id` of the red-flags/interventions in the url it self.
- To make sure the right people consumes this API, who ever is hitting this endpoint should only use his/her  JWT token sent in headers that they received when they created credentials to this API or Sign in to it.
- Employee should receive an message specifying that the red-flags/interventions was successfully deleted or an error with description if it didn't.

And also the data provided should meet this API validation expectations

After deleting the article everything associated to it should also be deleted 

have the following endpoint work 
- DELETE /api/v1/red-flags/`:red-flag-id`

### How should this be manually tested?
after cloning this repository, od into it and RUN `npm i` after `npm start`
- Using postman test the endpoint above

Set key: Content-type value: application/json
make sure you have a JWT token in the headers with key:token value: JWT token generated while signing up or signing in
### Any background context you want to provide?
N/A
### What are the relevant pivot tracker stories ?
#169853269
https://www.pivotaltracker.com/story/show/169853269

#### screenshots if available?
![image](https://user-images.githubusercontent.com/37307172/69194637-46a96b80-0b32-11ea-9890-e25e0cc4099b.png)
 