### PR TITLE
 #170084238 Fetch a specific red-flag from database

### DIFF
--- a/server/api/v2/controllers/redFlagController.js
+++ b/server/api/v2/controllers/redFlagController.js
@@ -96,20 +96,27 @@ static async getOne(req, res) {
     if (!checkInt(red_flag_id)) {
         responseMsg.errorMsg(res, 403, 'red-flag-id must be an integer and less than 8 in length')
     }
-    let item = findById(redFlags, red_flag_id)
-    if (!item) return responseMsg.errorMsg(res, 404, 'red-flag-id not found')
+    const fetch_text = 'SELECT * FROM flags WHERE id = $1'
+
+    const { rows } = await pool.query(fetch_text, [red_flag_id])
+    if (!rows[0]) {
+        return res.status(404).json({
+            status: 404,
+            message: 'red-flag-id not found'
+        });
+    }
     const newItem = {
-        id: item.id,
-        createdBy: item.created_by,
-        title: item.title,
-        type: item.type,
-        comment: item.comment,
-        status: item.status,
-        location: item.location,
-        labels: item.labels,
-        images: item.images,
-        videos: item.videos,
-        createdOn: item.created_on
+        id: rows[0].id,
+        createdBy: rows[0].created_by,
+        title: rows[0].title,
+        type: rows[0].type,
+        comment: rows[0].comment,
+        status: rows[0].status,
+        location: rows[0].location,
+        labels: rows[0].labels,
+        images: rows[0].images,
+        videos: rows[0].videos,
+        createdOn: rows[0].created_on
     }
     res.status(200).json({
         status: 200,

--- a/server/test/v2/specific.test.js
+++ b/server/test/v2/specific.test.js
@@ -12,7 +12,7 @@ chai.expect();
 describe('Fetch red-flag/intervention', () => {
     describe('Get specific red-flag/intervention', () => {
         it('User should receive a successful get red-flag/intervention message', (done) => {
-            supertest('http://localhost:8080/api/v1')
+            supertest('http://localhost:8080/api/v2')
                 .get('/red-flags/2')
                 .set('Accept', 'application/json')
                 .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCROR0hPMWJzNHNhdXAzN0h3S3Mya3MuUVFyYkRMbHNpWDRHcFNOaVBYcTZCSjFUdlJ2cEFjYSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzUwMTcwNTN9.eqtNHB03N5-cQRpWa72-MTXYO7AKJq5as5-_JwEyAp0')
@@ -26,7 +26,7 @@ describe('Fetch red-flag/intervention', () => {
     });
     describe('Get specific red-flag/intervention', () => {
         it('User should receive an error get red-flag id format', (done) => {
-            supertest('http://localhost:8080/api/v1')
+            supertest('http://localhost:8080/api/v2')
                 .get('/red-flags/g')
                 .set('Accept', 'application/json')
                 .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCROR0hPMWJzNHNhdXAzN0h3S3Mya3MuUVFyYkRMbHNpWDRHcFNOaVBYcTZCSjFUdlJ2cEFjYSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzUwMTcwNTN9.eqtNHB03N5-cQRpWa72-MTXYO7AKJq5as5-_JwEyAp0')


### PR DESCRIPTION
### What does this Pr do ?
Fetch a specific red-flag record
### Description of the task to be completed ?
- Users should be able to view a specific red-flag/intervention only if it exists in database
- Users can only fetch the articles by their `id`s
- To view an red-flag/intervention Users should send the `id` of the red-flag/intervention in the url it self.
- To make sure the right people consumes this API, who ever is hitting this endpoint should only use his/her  JWT token that  they received when they created credentials to this API or Sign in to it sent in headers.
- Users should receive a message specifying that they successfully fetched with the article and its description or an error with description if it didn't.
- add testing

have the following endpoint work 
- GET /api/v2/red-flags/`:red-flag-id`

### How should this be manually tested?
after cloning this repository, od into it and RUN `npm i` after `npm start`
- Using postman test the endpoint above

Set key: Content-type value: application/json
make sure you have a JWT token in the headers with key:token value: JWT token generated while signing up or signing in
### Any background context you want to provide?
N/A
### What are the relevant pivot tracker stories ?
 #170084238
https://www.pivotaltracker.com/story/show/170084238

#### screenshots if available?
![image](https://user-images.githubusercontent.com/37307172/70083173-9862f300-1614-11ea-97fe-aaaaddda906f.png)
