### PR TITLE
#170085326 Fetch all red-flags from database

### DIFF
--- a/server/api/v2/controllers/redFlagController.js
+++ b/server/api/v2/controllers/redFlagController.js
@@ -130,7 +130,10 @@ static async getOne(req, res) {
     */
     static async getAll(req, res) {
         const data = []
-        await redFlags.forEach(item => {
+        const fetch_text = 'SELECT * FROM flags'
+
+        const { rows } = await pool.query(fetch_text)
+        await rows.forEach(item => {
             const newItem = {
                 id: item.id,
                 createdBy: item.created_by,

--- a/server/test/v2/specific.test.js
+++ b/server/test/v2/specific.test.js
@@ -40,7 +40,7 @@ describe('Fetch red-flag/intervention', () => {
     });
     describe('Get all red-flag/intervention', () => {
         it('User should receive a successful get red-flag/intervention message', (done) => {
-            supertest('http://localhost:8080/api/v1')
+            supertest('http://localhost:8080/api/v2')
                 .get('/red-flags')
                 .set('Accept', 'application/json')
                 .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCROR0hPMWJzNHNhdXAzN0h3S3Mya3MuUVFyYkRMbHNpWDRHcFNOaVBYcTZCSjFUdlJ2cEFjYSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzUwMTcwNTN9.eqtNHB03N5-cQRpWa72-MTXYO7AKJq5as5-_JwEyAp0')


### PR DESCRIPTION
### What does this Pr do ?
User should be able to fetch all red-flag records
### Description of the task to be completed ?
- Users should only be able to view stored red-flags/interventions
- To make sure the right people consumes this API, who ever is hitting this endpoint should only use his/her  JWT token that  they received when they created credentials to this API or Sign in to it sent in headers.
- Employee should receive an message specifying that fetching all  red-flags/interventions was successfully and receive all  red-flags/interventions or an error with description if it didn't.
- add testing

have the following endpoint work 
- GET /api/v2/red-flags

### How should this be manually tested?
after cloning this repository, od into it and RUN `npm i` after `npm start`
- Using postman test the endpoint above

Set key: Content-type value: application/json
make sure you have a JWT token in the headers with key:token value: JWT token generated while signing up or signing in
### Any background context you want to provide?
N/A
### What are the relevant pivot tracker stories ?
#170085326
https://www.pivotaltracker.com/story/show/170085326

#### screenshots if available?
![image](https://user-images.githubusercontent.com/37307172/70085036-2ab8c600-1618-11ea-9bd1-791cafcaec34.png)
