### PR TITLE
#170086011 Delete red-flag/intervention from database

### DIFF
--- a/server/api/v2/controllers/authanticationController.js
+++ b/server/api/v2/controllers/authanticationController.js
@@ -1,6 +1,5 @@
 import jwt from 'jsonwebtoken'
 import { Pool } from 'pg'
-import users from "../models/user"
 import hashPassword from '../heplpers/hash'
 import comparePassword from '../heplpers/compareHash'
 import dotenv from 'dotenv'

--- a/server/api/v2/heplpers/findById.js
+++ b/server/api/v2/heplpers/findById.js
@@ -1,3 +1,0 @@
-export default (model, valueId) => {
-    return model.find(obj => obj.id ==  valueId)
-}

--- a/server/api/v2/heplpers/id_auto_inc.js
+++ b/server/api/v2/heplpers/id_auto_inc.js
@@ -1,3 +1,0 @@
-export default (model) => {
-    return model.length <= 0 ? 1 : model[model.length - 1].id + 1
-}

--- a/server/api/v2/middlewares/authValidation/signupValidator.js
+++ b/server/api/v2/middlewares/authValidation/signupValidator.js
@@ -1,5 +1,3 @@
-import users from "../../models/user"
-import id_auto_inc from "../../heplpers/id_auto_inc"
 import responseMsg from '../../heplpers/responseMsg'
 
 
@@ -15,7 +13,6 @@ export default (req, res, next) => {
         isAdmin
     } = req.body;
     const user = {
-        id: id_auto_inc(users),
         first_name: firstName,
         last_name: lastName,
         email,
@@ -25,10 +22,6 @@ export default (req, res, next) => {
         is_admin: isAdmin
     };
     const schema = joi.object().keys({
-        id: joi
-            .number()
-            .integer()
-            .required(),
         first_name: joi
             .string()
             .regex(/^[a-zA-Z0-9\s]{3,25}$/)

--- a/server/api/v2/middlewares/redFlagValidation/createRedFlagValidator.js
+++ b/server/api/v2/middlewares/redFlagValidation/createRedFlagValidator.js
@@ -1,7 +1,3 @@
-import fs from 'fs'
-
-import redFlag from "../../models/red-flag"
-import id_auto_inc from "../../heplpers/id_auto_inc"
 import joi from "joi"
 
 import responseMsg from '../../heplpers/responseMsg'
@@ -41,7 +37,6 @@ export default (req, res, next) => {
 
 
                         const artl = {
-                            id: id_auto_inc(redFlag),
                             created_by: token.id,
                             title,
                             type,
@@ -51,10 +46,6 @@ export default (req, res, next) => {
                             created_on: new Date()
                         };
                         const schema = joi.object().keys({
-                            id: joi
-                                .number()
-                                .integer()
-                                .required(),
                             created_by: joi
                                 .number()
                                 .integer()

--- a/server/api/v2/models/red-flag.js
+++ b/server/api/v2/models/red-flag.js
@@ -1,20 +1,3 @@
-const redFlags = [{
-        "id": 1,
-        "created_by": 1,
-        "title": "this is the tittle",
-        "type": "red-flag",
-        "comment": "this is the comment about the red-flag",
-        "created_on": "2019-11-28T15:07:49.467Z",
-        "status": "draft",
-        "location": "-90,3",
-        "labels": [
-            "bro",
-            "we @ are",
-            "here"
-        ],
-        "images": [],
-        "videos": []
-
-}]
+const redFlags = []
 
 export default redFlags

--- a/server/test/v2/updateLocation.test.js
+++ b/server/test/v2/updateLocation.test.js
@@ -135,7 +135,7 @@ describe('Location', () => {
     describe('Delete red-flag/intervention', () => {
         describe('delete specific red-flag/intervention', () => {
             it('User should receive a successful delete red-flag/intervention message', (done) => {
-                supertest('http://localhost:8080/api/v1')
+                supertest('http://localhost:8080/api/v2')
                     .delete('/red-flags/2')
                     .set('Accept', 'application/json')
                     .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaXNBZG1pbiI6dHJ1ZSwiaWF0IjoxNTc1Mjg0MzE0fQ.h63MpVqFhQVBFunnFS9f4-_VqsdbGhozMt62c0Zgkzc')


### PR DESCRIPTION
### What does this Pr do ?
User should be able to delete their red-flags/interventions
### Description of the task to be completed ?
- Users should only be able to delete stored red-flags/interventions
- To make sure the right people consumes this API, who ever is hitting this endpoint should only use his/her  JWT token that  they received when they created credentials to this API or Sign in to it sent in headers.
- Employee should receive an message specifying that deleting a  red-flag/intervention was successfully and receive all  red-flags/interventions or an error with description if it didn't.
- add testing

have the following endpoint work 
- DELETE /api/v2/red-flags/`red-flag-id`

### How should this be manually tested?
after cloning this repository, od into it and RUN `npm i` after `npm start`
- Using postman test the endpoint above

Set key: Content-type value: application/json
make sure you have a JWT token in the headers with key:token value: JWT token generated while signing up or signing in
### Any background context you want to provide?
N/A
### What are the relevant pivot tracker stories ?
#170086011
https://www.pivotaltracker.com/story/show/170086011

#### screenshots if available?
![image](https://user-images.githubusercontent.com/37307172/70088752-90f51700-161f-11ea-84d0-580169c6a426.png)

