### PR TITLE
#170096083 Admin can change status (server) database

### DIFF
--- a/server/api/v2/controllers/adminController.js
+++ b/server/api/v2/controllers/adminController.js
@@ -1,0 +1,35 @@
+import { Pool } from 'pg'
+import responseMsg from '../heplpers/responseMsg'
+import checkInt from '../heplpers/checkInt'
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL
+});
+export default class adminController {
+    /**
+   * @description This helps the authorized User to update an existing red-flag/intervention location
+   * @param  {object} req - The request object
+   * @param  {object} res - The response object
+   */
+    static async updateStatus(req, res) {
+        const value = req.value
+        const updateOne = `UPDATE flags SET status=($2) where id=($1) returning *`
+        const fetch_text = 'SELECT * FROM flags WHERE id = $1'
+
+        const { rows } = await pool.query(fetch_text, [value.red_flag_id])
+        if (!rows[0]) {
+            return res.status(404).json({
+                status: 404,
+                message: 'red-flag-id not found'
+            });
+        }
+        const response = await pool.query(updateOne, [value.red_flag_id, value.status]);
+        res.status(200).json({
+            status: 200,
+            data: [{
+                id: response.rows[0].id,
+                message: 'Updated red-flag record’s status'
+            }]
+        })
+    }
+}

--- a/server/api/v2/controllers/redFlagController.js
+++ b/server/api/v2/controllers/redFlagController.js
@@ -96,12 +96,8 @@ static async getOne(req, res) {
     const fetch_text = 'SELECT * FROM flags WHERE id = $1'
 
     const { rows } = await pool.query(fetch_text, [red_flag_id])
-    if (!rows[0]) {
-        return res.status(404).json({
-            status: 404,
-            message: 'red-flag-id not found'
-        });
-    }
+    if (!rows[0]) return responseMsg.errorMsg(res, 404, 'red-flag-id not found')
+    
     const newItem = {
         id: rows[0].id,
         createdBy: rows[0].created_by,
@@ -159,9 +155,8 @@ static async getOne(req, res) {
     */
     static async delete(req, res) {
         const { red_flag_id } = req.params
-        if (!checkInt(red_flag_id)) {
-            responseMsg.errorMsg(res, 403, 'red-flag-id must be an integer and less than 8 in length')
-        }
+        if (!checkInt(red_flag_id)) return responseMsg.errorMsg(res, 403, 'red-flag-id must be an integer and less than 8 in length')
+        
         const deleteOne = `DELETE FROM flags WHERE id=($1) returning *`
         const fetch_text = 'SELECT * FROM flags WHERE id = $1'
 

--- a/server/api/v2/index.js
+++ b/server/api/v2/index.js
@@ -1,6 +1,7 @@
 import app from '../../app'
 import authRoutes from "./routes/auth"
 import redFlagRoutes from "./routes/redFlag-Intervention"
+import adminRoutes from "./routes/admin"
 import responseMsg from './heplpers/responseMsg'
 
 
@@ -9,4 +10,5 @@ app.get("/api/v2", (req, res) => {
 });
 app.use("/api/v2/auth", authRoutes);
 app.use("/api/v2/red-flags", redFlagRoutes);
+app.use("/api/v2/admin", adminRoutes);
 

--- a/server/api/v2/middlewares/redFlagValidation/createRedFlagValidator.js
+++ b/server/api/v2/middlewares/redFlagValidation/createRedFlagValidator.js
@@ -7,7 +7,33 @@ export default (req, res, next) => {
     try {
                 const imageUrls = []
                 const videoUrls = []
-                const { location, labels } = req.body
+                const { location, labels, images, videos } = req.body
+
+        // if (!category) throw {
+        //     status: 204,
+        //     message: 'please provide atleast one category'
+        // }
+        if (images && !Array.isArray(images) || videos && !Array.isArray(videos)) return responseMsg.errorMsg(res, 400, 'images and videos must be type of array')
+        
+        const regImages = /(http(s?):)([/|.|\w|\s|-])*\.(?:jpg|gif|png)/g
+        const regVideos = /(http(s?):)([/|.|\w|\s|-])*\.(?:mp4)/g
+        
+        const check = (x,reg,storage) => {
+            return x.every(i=> {
+                if (typeof i !== 'string') return responseMsg.errorMsg(res, 400, 'all images or videos must be strings and image or video urls')
+                
+                const mn = i.replace(/(^\ *)|(\ *$)/g, '').replace(/ +/g, " ")
+                storage.push(mn)
+                return mn.match(reg) ? true : false
+
+            });
+        }
+
+        if (images && !check(images, regImages, imageUrls)) return responseMsg.errorMsg(res, 400, 'all images must be strings and image urls')
+        
+        if (videos && !check(videos, regVideos, videoUrls)) return responseMsg.errorMsg(res, 400, 'all vidoes must be strings and video urls')
+
+
                 if (location && typeof location === 'string' && labels && typeof labels === 'string') {
                     // labels
                     const labelsItems = labels.split(',')
@@ -103,9 +129,6 @@ export default (req, res, next) => {
                 } else {
                     responseMsg.errorMsg(res, 400, 'location and labels are compulsory and must be type of string')
                 }
-            
-        
-
     } catch (error) {
         responseMsg.errorMsg(res, 500, 'an error happened we are working on it')
 

--- a/server/api/v2/middlewares/redFlagValidation/statusRedFlagValidator.js
+++ b/server/api/v2/middlewares/redFlagValidation/statusRedFlagValidator.js
@@ -1,0 +1,40 @@
+import joi from 'joi'
+import responseMsg from '../../heplpers/responseMsg'
+import checkInt from '../../heplpers/checkInt'
+
+export default (req, res, next) => {
+    const token = res.token
+    const { status } = req.body
+    const { red_flag_id } = req.params
+
+    if (!token.isAdmin || token.isAdmin !== true) {
+        responseMsg.errorMsg(res, 403, 'you have no rights over this endpoint')
+    }
+    if (!checkInt(red_flag_id)) {
+        responseMsg.errorMsg(res, 400, 'red-flag-id must be an integer and less than 8 in length')
+    }
+    const newComment = {
+        status,
+        red_flag_id: Number(red_flag_id)
+    }
+    const schema = joi.object().keys({
+        red_flag_id: joi
+            .number()
+            .integer()
+            .required(),
+        status: joi
+            .string()
+            .trim()
+            .valid("under-investigation", "resolved", "rejected")
+            .required(),
+    });
+    const { error, value } = joi.validate(newComment, schema);
+
+    if (error) {
+
+        responseMsg.errorMsg(res, 403, error.details[0].message)
+    } else {
+        req.value = value;
+        next();
+    }
+}

--- a/server/api/v2/routes/admin.js
+++ b/server/api/v2/routes/admin.js
@@ -1,0 +1,11 @@
+import express from 'express'
+
+import authanticationJWT from "../middlewares/authJWT"
+import statusRedFlagValidator from "../middlewares/redFlagValidation/statusRedFlagValidator"
+import adminController from "../controllers/adminController"
+
+
+const router = express.Router();
+router.patch("/:red_flag_id/status", authanticationJWT, statusRedFlagValidator, adminController.updateStatus)
+
+export default router;

--- a/server/test/v2/createRedFlag.test.js
+++ b/server/test/v2/createRedFlag.test.js
@@ -33,6 +33,100 @@ describe('Red-flag/Intervention', () => {
         });
     });
     describe('Post a red-flag/intervention', () => {
+        it('User should receive an error create message about invalid input images not array', (done) => {
+            supertest('http://localhost:8080/api/v2')
+                .post('/red-flags')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCROR0hPMWJzNHNhdXAzN0h3S3Mya3MuUVFyYkRMbHNpWDRHcFNOaVBYcTZCSjFUdlJ2cEFjYSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzUwMTcwNTN9.eqtNHB03N5-cQRpWa72-MTXYO7AKJq5as5-_JwEyAp0')
+
+                .set('Accept', 'application/json')
+                .send({
+                    title: "this is the tittle",
+                    labels: "1",
+                    type: "interventio",
+                    comment: "this is the comment about the red-flag",
+                    location: "-90,3",
+                    images: "1"
+                })
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(400);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
+    describe('Post a red-flag/intervention', () => {
+        it('User should receive an error create message about invalid input image type string', (done) => {
+            supertest('http://localhost:8080/api/v2')
+                .post('/red-flags')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCROR0hPMWJzNHNhdXAzN0h3S3Mya3MuUVFyYkRMbHNpWDRHcFNOaVBYcTZCSjFUdlJ2cEFjYSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzUwMTcwNTN9.eqtNHB03N5-cQRpWa72-MTXYO7AKJq5as5-_JwEyAp0')
+
+                .set('Accept', 'application/json')
+                .send({
+                    title: "this is the tittle",
+                    labels: "1",
+                    type: "interventio",
+                    comment: "this is the comment about the red-flag",
+                    location: "-90,3",
+                    images: ["https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"],
+                    videos: [1]
+                })
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(400);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
+    describe('Post a red-flag/intervention', () => {
+        it('User should receive an error create message about invalid input videoUrls format', (done) => {
+            supertest('http://localhost:8080/api/v2')
+                .post('/red-flags')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCROR0hPMWJzNHNhdXAzN0h3S3Mya3MuUVFyYkRMbHNpWDRHcFNOaVBYcTZCSjFUdlJ2cEFjYSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzUwMTcwNTN9.eqtNHB03N5-cQRpWa72-MTXYO7AKJq5as5-_JwEyAp0')
+
+                .set('Accept', 'application/json')
+                .send({
+                    title: "this is the tittle",
+                    labels: "1",
+                    type: "interventio",
+                    comment: "this is the comment about the red-flag",
+                    location: "-90,3",
+                    images: ["https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"],
+                    videos: ["1"]
+                })
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(400);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
+    describe('Post a red-flag/intervention', () => {
+        it('User should receive an error create message about invalid input imageUrls format', (done) => {
+            supertest('http://localhost:8080/api/v2')
+                .post('/red-flags')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCROR0hPMWJzNHNhdXAzN0h3S3Mya3MuUVFyYkRMbHNpWDRHcFNOaVBYcTZCSjFUdlJ2cEFjYSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzUwMTcwNTN9.eqtNHB03N5-cQRpWa72-MTXYO7AKJq5as5-_JwEyAp0')
+
+                .set('Accept', 'application/json')
+                .send({
+                    title: "this is the tittle",
+                    labels: "1",
+                    type: "interventio",
+                    comment: "this is the comment about the red-flag",
+                    location: "-90,3",
+                    images: ["1"]
+                })
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(400);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
+    describe('Post a red-flag/intervention', () => {
         it('User should receive an error create message about invalid input', (done) => {
             supertest('http://localhost:8080/api/v2')
                 .post('/red-flags')

--- a/server/test/v2/specific.test.js
+++ b/server/test/v2/specific.test.js
@@ -38,6 +38,20 @@ describe('Fetch red-flag/intervention', () => {
                 });
         });
     });
+    describe('Get specific red-flag/intervention', () => {
+        it('User should receive an error get red-flag not found', (done) => {
+            supertest('http://localhost:8080/api/v2')
+                .get('/red-flags/67')
+                .set('Accept', 'application/json')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3Jpc0B5YWhvby5mciIsInBob25lX251bWJlciI6IjEyMzQ1Njc4OTAiLCJwYXNzd29yZCI6IiQyYSQxMCROR0hPMWJzNHNhdXAzN0h3S3Mya3MuUVFyYkRMbHNpWDRHcFNOaVBYcTZCSjFUdlJ2cEFjYSIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1NzUwMTcwNTN9.eqtNHB03N5-cQRpWa72-MTXYO7AKJq5as5-_JwEyAp0')
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(404);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
     describe('Get all red-flag/intervention', () => {
         it('User should receive a successful get red-flag/intervention message', (done) => {
             supertest('http://localhost:8080/api/v2')

--- a/server/test/v2/updateLocation.test.js
+++ b/server/test/v2/updateLocation.test.js
@@ -134,6 +134,22 @@ describe('Location', () => {
     });
     describe('Delete red-flag/intervention', () => {
         describe('delete specific red-flag/intervention', () => {
+            it('User should receive an error about red-flag/intervention not found message', (done) => {
+                supertest('http://localhost:8080/api/v2')
+                    .delete('/red-flags/67')
+                    .set('Accept', 'application/json')
+                    .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaXNBZG1pbiI6dHJ1ZSwiaWF0IjoxNTc1Mjg0MzE0fQ.h63MpVqFhQVBFunnFS9f4-_VqsdbGhozMt62c0Zgkzc')
+                    .expect('Content-Type', /json/)
+                    .end((err, res) => {
+                        res.should.have.status(404);
+                        res.should.be.a('object');
+                        done();
+                    });
+            });
+        });
+    })
+    describe('Delete red-flag/intervention', () => {
+        describe('delete specific red-flag/intervention', () => {
             it('User should receive a successful delete red-flag/intervention message', (done) => {
                 supertest('http://localhost:8080/api/v2')
                     .delete('/red-flags/2')

--- a/server/test/v2/wstatusAdmin.test.js
+++ b/server/test/v2/wstatusAdmin.test.js
@@ -1,0 +1,104 @@
+import chai from 'chai'
+import chaiHttp from 'chai-http'
+import supertest from 'supertest'
+import app from '../../app.js'
+
+
+chai.use(chaiHttp);
+chai.should();
+chai.expect();
+
+
+describe('Status', () => {
+    describe('Update status', () => {
+        it('User should receive a successful updated status message', (done) => {
+            supertest('http://localhost:8080/api/v2')
+                .patch('/admin/1/status')
+                .set('Accept', 'application/json')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NCwiaXNBZG1pbiI6dHJ1ZSwiaWF0IjoxNTc1NDQ3OTkzfQ.MqC94Wbu8glQUcXOsVQhR9PhPXZt42yOaWW7eTuMNFY')
+
+                .send({
+                    "status": "rejected"
+                })
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
+    describe('Update status', () => {
+        it('User should receive an error message about red-flag not found', (done) => {
+            supertest('http://localhost:8080/api/v2')
+                .patch('/admin/67/status')
+                .set('Accept', 'application/json')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NCwiaXNBZG1pbiI6dHJ1ZSwiaWF0IjoxNTc1NDQ3OTkzfQ.MqC94Wbu8glQUcXOsVQhR9PhPXZt42yOaWW7eTuMNFY')
+
+                .send({
+                    "status": "rejected"
+                })
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(404);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
+    describe('Update status', () => {
+        it('User should receive an error message about red-flag id', (done) => {
+            supertest('http://localhost:8080/api/v2')
+                .patch('/admin/g/status')
+                .set('Accept', 'application/json')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NCwiaXNBZG1pbiI6dHJ1ZSwiaWF0IjoxNTc1NDQ3OTkzfQ.MqC94Wbu8glQUcXOsVQhR9PhPXZt42yOaWW7eTuMNFY')
+
+                .send({
+                    "status": "rejected"
+                })
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(400);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
+    describe('Update status', () => {
+        it('User should receive an error message about format of status', (done) => {
+            supertest('http://localhost:8080/api/v2')
+                .patch('/admin/1/status')
+                .set('Accept', 'application/json')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3RfbmFtZSI6ImJpaGlyZSIsImxhc3RfbmFtZSI6ImJvcmlzIiwiZW1haWwiOiJtdWhpcmVib3JpQHlhaG9vLmZyIiwicGhvbmVfbnVtYmVyIjoiMTIzNDU2Nzg5MCIsInBhc3N3b3JkIjoiJDJhJDEwJHNJNEhReUVIeUtmUUNxV3lwd21rSk9XY2RVaFBSMFlVUGVrbVkwM3prY04xR1ROZk9PellpIiwiaXNfYWRtaW4iOnRydWUsImlhdCI6MTU3NDk1MzM3Nn0.Qlmyo_ZNTdvkQvARFlUcfqZz-EOWK4bjV3gfC8zTxk0')
+
+                .send({
+                    "status": "1"
+                })
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(403);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
+    describe('Update status', () => {
+        it('User should receive an error message about not admin', (done) => {
+            supertest('http://localhost:8080/api/v2')
+                .patch('/admin/1/status')
+                .set('Accept', 'application/json')
+                .set('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywiaXNBZG1pbiI6ZmFsc2UsImlhdCI6MTU3NTQ3MTY2N30.p2AyW8tBIesp8OOqOKRCqmiaFjxIZztzwW2tLO-j1N0')
+
+                .send({
+                    "status": "rejected"
+                })
+                .expect('Content-Type', /json/)
+                .end((err, res) => {
+                    res.should.have.status(403);
+                    res.should.be.a('object');
+                    done();
+                });
+        });
+    });
+
+})


### PR DESCRIPTION
### What does this Pr do ?
Change a specific red-flag/Intervention status
### Description of the task to be completed ?
- Admin should be able to change red-flags/interventions as `under-investigation` ;`rejected` ;`resolved`
- To update status of red-flags/interventions Admin should send the `id` of the red-flags/interventions in the url it self and be an Admin.
- To make sure the right people consumes this API, who ever is hitting this endpoint should only use his/her  JWT token sent in headers that they received when they created credentials to this API or Sign in to it.
- Admin should receive an message specifying that the red-flags/interventions was successfully updated or an error with description if it didn't.

And also the data provided should meet this API validation expectations

have the following endpoint work 
- PATCH /api/v2/admin/`:red-flag-id`/status

### How should this be manually tested?
after cloning this repository, od into it and RUN `npm i` after `npm start`
- Using postman test the endpoint above

Set key: Content-type value: application/json
make sure you have a JWT token in the headers with key:token value: JWT token generated while signing up or signing in
### Any background context you want to provide?
N/A
### What are the relevant pivot tracker stories ?
#170096083
https://www.pivotaltracker.com/story/show/170096083

#### screenshots if available?
![image](https://user-images.githubusercontent.com/37307172/70158878-a8d0a780-16c0-11ea-8cc9-04330834518f.png)
